### PR TITLE
Updated 'verify_ssl' parameter and converted it to the boolean

### DIFF
--- a/library/opsview_bsm_component.py
+++ b/library/opsview_bsm_component.py
@@ -368,7 +368,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
 

--- a/library/opsview_bsm_service.py
+++ b/library/opsview_bsm_service.py
@@ -349,7 +349,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
 

--- a/library/opsview_flow_source.py
+++ b/library/opsview_flow_source.py
@@ -409,7 +409,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
     host_manager = get_config_manager(ov_client, 'hosts')

--- a/library/opsview_hashtag.py
+++ b/library/opsview_hashtag.py
@@ -405,7 +405,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
 

--- a/library/opsview_host.py
+++ b/library/opsview_host.py
@@ -730,7 +730,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
 

--- a/library/opsview_host_group.py
+++ b/library/opsview_host_group.py
@@ -345,7 +345,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
 

--- a/library/opsview_login.py
+++ b/library/opsview_login.py
@@ -101,7 +101,7 @@ def main():
     ov_client = init_client(username=module.params['username'],
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     status = {
         'changed': True,

--- a/library/opsview_monitoring_server.py
+++ b/library/opsview_monitoring_server.py
@@ -387,7 +387,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     manager = get_config_manager(ov_client, MANAGER_OBJ_TYPE)
 

--- a/library/opsview_reload.py
+++ b/library/opsview_reload.py
@@ -214,7 +214,7 @@ def main():
                             password=module.params['password'],
                             endpoint=module.params['endpoint'],
                             token=module.params['token'],
-                            verify=module.params['verify_ssl'])
+                            verify=module.boolean(module.params['verify_ssl']))
 
     status = do_reload(ov_client)
     module.exit_json(**status)


### PR DESCRIPTION
By default, this module is going to fail for self-signed SSL URLs because "verify_ssl" variable is not converted to the boolean type, this fix will resolve this issue.